### PR TITLE
Updated to add GUID

### DIFF
--- a/yasfb/__init__.py
+++ b/yasfb/__init__.py
@@ -111,6 +111,7 @@ def create_feed_item(app, pagename, templatename, ctx, doctree):
                  + ctx['current_page_name']
                  + '.html'),
         'description': clean_description(ctx.get('body')),
+        'guid': ctx['current_page_name'],
         'pubDate': pubdate,
     }
     if 'author' in metadata:
@@ -128,7 +129,7 @@ def clean_description(body):
     out = re.sub("<p>By (.|\n)*?</p>", "", out)
 
     #remove HTML tags
-    out = re.sub("<.*?>|\\n|¶", " ", out)
+    out = re.sub("<.*?>|\\n|Â¶", " ", out)
 
     #truncate to 500 characters
     out = out[:200] + '...'


### PR DESCRIPTION
Using current_page_name since that's the unique part of the URL. GUID sub-element isn't actually a GUID, it's a unique page identifier with the feed used to determine if an item is new. Spec: http://cyber.law.harvard.edu/rss/rss.html#ltguidgtSubelementOfLtitemgt